### PR TITLE
added link to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Medium SDK for PHP
 ================
 [![Build Status](https://travis-ci.org/jonathantorres/medium-sdk-php.svg)](https://travis-ci.org/jonathantorres/medium-sdk-php)
 [![Version](https://img.shields.io/packagist/v/jonathantorres/medium-sdk.svg)](https://packagist.org/packages/jonathantorres/medium-sdk)
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/Medium/functions?utm_source=MediumGithub&utm_medium=button&utm_content=Vender_GitHub)
 
 Open source SDK for integrating [Medium](https://medium.com)'s OAuth2 API into your PHP application. Please note that Medium's API is still on an early stage and this implementation is not final. Breaking changes will happen. This SDK is unofficial. Medium's API documentation can be found [here](https://github.com/Medium/medium-api-docs).
 


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out Medium API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!